### PR TITLE
Ensure Jackson version is defined by Bootique core module, not Link Rest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 		<bootique-jersey-version>0.19</bootique-jersey-version>
 		<link-rest-version>2.3</link-rest-version>
 
-		<!-- Used for tests only; runtime jersey comes as a transient dependency 
+		<!-- Used for tests only; runtime jersey comes as a transient dependency
 			from bootique-jersey-version -->
 		<jersey-version>2.21</jersey-version>
 	</properties>
@@ -85,11 +85,20 @@
 				<groupId>com.nhl.link.rest</groupId>
 				<artifactId>link-rest</artifactId>
 				<version>${link-rest-version}</version>
-				<!-- Ensure cayenne version from bootique-cayenne is used -->
+				<!-- Ensure cayenne version from bootique-cayenne is used;
+					 ensure jackson version from bootique core is used -->
 				<exclusions>
 					<exclusion>
 						<groupId>org.apache.cayenne</groupId>
 						<artifactId>cayenne-server</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>jackson-databind</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>com.fasterxml.jackson.core</groupId>
+						<artifactId>jackson-core</artifactId>
 					</exclusion>
 				</exclusions>
 			</dependency>


### PR DESCRIPTION
@andrus , tried to push directly to origin, returns 403 for me

The particular problem that we've encountered was that when using Bootique's ConfigFactory the implementation of `com.fasterxml.jackson.databind.deser.impl.BeanPropertyMap#replace(SettableBeanProperty)` in Jackson version 2.6.3 (used in LR, overriding Bootique's 2.6.4 in certain application configurations) was causing deserialization errors for camel-cased properties (could not find setter method).